### PR TITLE
fix: Prevent hover popup and use direct LSP request

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 {
-  'sim-maz/show-type.nvim',
+  'your-github-username/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -25,7 +25,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 use {
-  'sim-maz/show-type.nvim',
+  'your-github-username/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -35,7 +35,7 @@ use {
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'sim-maz/show-type.nvim'
+Plug 'your-github-username/show-type.nvim'
 ```
 
 Then, in your `init.lua` or somewhere after the plugin is loaded:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -25,7 +25,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 use {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -35,7 +35,7 @@ use {
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'your-github-username/show-type.nvim'
+Plug 'sim-maz/show-type.nvim'
 ```
 
 Then, in your `init.lua` or somewhere after the plugin is loaded:

--- a/lua/show_type/init.lua
+++ b/lua/show_type/init.lua
@@ -19,40 +19,41 @@ local function get_type_from_hover(hover_results)
   end
 
   local message = ""
-  for _, result in ipairs(hover_results) do
-    if result.contents then
-      if type(result.contents) == "table" then
-        for _, line in ipairs(result.contents) do
-          message = message .. line .. "\n"
+  -- The result from buf_request_all is a map of client_id -> result
+  for _, client_result in pairs(hover_results) do
+    if client_result.result and client_result.result.contents then
+      local contents = client_result.result.contents
+      if type(contents) == "table" then
+        for _, line in ipairs(contents) do
+          if type(line) == 'string' then
+            message = message .. line .. "\n"
+          end
         end
       else
-        message = message .. result.contents .. "\n"
+        message = message .. contents .. "\n"
       end
     end
   end
 
-  -- This is a heuristic. Different LSPs format hover results differently.
-  -- We'll look for lines that look like type definitions.
-  -- For example, in typescript, it might be `(property) myVar: string`
-  -- or for a function `function myFunc(): number`
-  -- We'll try to extract the part after the colon.
-  local type_info = message:match(":%s*(.*)")
-  if type_info then
-    return type_info:gsub("^%s*", ""):gsub("%s*$", "")
+  if message == "" then
+    return nil
   end
 
-  -- Fallback to the first line if no colon is found
-  return message:match("^[^\n]*")
+  -- This is a heuristic. Different LSPs format hover results differently.
+  local type_info = message:match("```[a-zA-Z_]*\n(.-)```")
+  if not type_info then
+    type_info = message
+  end
+
+  return type_info:gsub("^\n*", ""):gsub("\n*$", "")
 end
 
 
 function M.show()
-  local original_hover_handler = vim.lsp.handlers["textDocument/hover"]
+  local bufnr = vim.api.nvim_get_current_buf()
+  local params = vim.lsp.util.make_position_params()
 
-  vim.lsp.handlers["textDocument/hover"] = function(_, _, result, _)
-    -- Restore the original handler
-    vim.lsp.handlers["textDocument/hover"] = original_hover_handler
-
+  local handler = function(_, result, _, _)
     if not result or vim.tbl_isempty(result) then
       config.notify_func("No type information found.")
       return
@@ -67,7 +68,7 @@ function M.show()
     end
   end
 
-  vim.lsp.buf.hover()
+  vim.lsp.buf_request_all(bufnr, 'textDocument/hover', params, handler)
 end
 
 return M


### PR DESCRIPTION
This commit fixes a bug where the plugin would show a hover popup instead of a notification.

The previous implementation tried to override the `textDocument/hover` handler, but this did not prevent the default hover UI from appearing.

The new implementation uses `vim.lsp.buf_request_all` to send a direct request to the LSP server for hover information. This avoids triggering the default hover popup and allows the plugin to correctly display the type information in a notification.

The type parsing logic has also been improved to better handle markdown code blocks in the hover response.