### PR TITLE
debug: Add logging to inspect LSP hover result

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 {
-  'sim-maz/show-type.nvim',
+  'your-github-username/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -25,7 +25,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 use {
-  'sim-maz/show-type.nvim',
+  'your-github-username/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -35,7 +35,7 @@ use {
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'sim-maz/show-type.nvim'
+Plug 'your-github-username/show-type.nvim'
 ```
 
 Then, in your `init.lua` or somewhere after the plugin is loaded:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -25,7 +25,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 use {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -35,7 +35,7 @@ use {
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'your-github-username/show-type.nvim'
+Plug 'sim-maz/show-type.nvim'
 ```
 
 Then, in your `init.lua` or somewhere after the plugin is loaded:

--- a/lua/show_type/init.lua
+++ b/lua/show_type/init.lua
@@ -53,19 +53,27 @@ function M.show()
   local bufnr = vim.api.nvim_get_current_buf()
   local params = vim.lsp.util.make_position_params()
 
-  local handler = function(_, result, _, _)
-    if not result or vim.tbl_isempty(result) then
-      config.notify_func("No type information found.")
+  local handler = function(err, result, _, _)
+    if err then
+      config.notify_func("LSP Error: " .. vim.inspect(err))
       return
     end
 
-    local type_info = get_type_from_hover(result)
-
-    if type_info and type_info ~= "" then
-      config.notify_func(type_info)
-    else
-      config.notify_func("No type information found.")
+    if not result or vim.tbl_isempty(result) then
+      config.notify_func("No type information found (empty or nil result).")
+      return
     end
+
+    -- For debugging, show the structure of the result
+    config.notify_func("LSP Result: " .. vim.inspect(result))
+
+    -- local type_info = get_type_from_hover(result)
+
+    -- if type_info and type_info ~= "" then
+    --   config.notify_func(type_info)
+    -- else
+    --   config.notify_func("No type information found.")
+    -- end
   end
 
   vim.lsp.buf_request_all(bufnr, 'textDocument/hover', params, handler)


### PR DESCRIPTION
This commit adds debugging code to the `show` function to inspect the structure of the result from `vim.lsp.buf_request_all`.

The `get_type_from_hover` function is temporarily disabled to prevent the runtime error. The handler now displays the raw result from the LSP server in a notification.

This is intended to help diagnose an issue where the structure of the LSP result was not what was expected.