### PR TITLE
docs: Improve mini.notify example and update "How it works"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -25,7 +25,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 use {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -35,7 +35,7 @@ use {
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'your-github-username/show-type.nvim'
+Plug 'sim-maz/show-type.nvim'
 ```
 
 Then, in your `init.lua` or somewhere after the plugin is loaded:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 {
-  'sim-maz/show-type.nvim',
+  'your-github-username/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -25,7 +25,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 use {
-  'sim-maz/show-type.nvim',
+  'your-github-username/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -35,7 +35,7 @@ use {
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'sim-maz/show-type.nvim'
+Plug 'your-github-username/show-type.nvim'
 ```
 
 Then, in your `init.lua` or somewhere after the plugin is loaded:
@@ -51,12 +51,18 @@ The `setup` function accepts a configuration table. The following options are av
 
 ### Example with `mini.notify`
 
-To use `mini.notify`, you can configure it like this:
+To use `mini.notify`, you can configure it like this. This example includes a check to see if `mini.notify` is available, and falls back to the standard `vim.notify` if it's not. This is recommended to avoid errors if `mini.notify` is not loaded.
 
 ```lua
 require('show_type').setup({
   notify_func = function(msg)
-    require('mini.notify').make(msg, 'info', { title = 'Type' })()
+    -- Use mini.notify if it's available, otherwise fall back to vim.notify
+    local success, mini_notify = pcall(require, 'mini.notify')
+    if success then
+      mini_notify.make(msg, 'info', { title = 'Type' })()
+    else
+      vim.notify(msg, vim.log.levels.INFO, { title = 'Type' })
+    end
   end
 })
 ```
@@ -72,6 +78,4 @@ vim.keymap.set('n', '<Leader>st', '<cmd>ShowType<cr>', { desc = 'Show Type' })
 
 ## How it works
 
-This plugin temporarily overrides the `textDocument/hover` LSP handler to capture the hover information without displaying the floating window. It then parses the hover information to extract the type and displays it using the configured notification function.
-
-This approach is a bit of a hack, but it's a simple and effective way to get the type information without requiring a custom LSP client.
+This plugin uses `vim.lsp.buf_request_all` to send a `textDocument/hover` request to the LSP server. This is done without triggering the default hover UI (floating window). It then parses the hover information to extract the type and displays it using the configured notification function.


### PR DESCRIPTION
This commit updates the `README.md` to provide a more robust example for integrating with `mini.notify`. The new example uses `pcall` to safely check if `mini.notify` is available, preventing errors if the plugin is not loaded.

The "How it works" section has also been updated to reflect the final implementation, which uses `vim.lsp.buf_request_all` instead of overriding the hover handler.