### PR TITLE
fix: Suppress position_encoding warning and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,14 @@ The `setup` function accepts a configuration table. The following options are av
 
 ### Example with `mini.notify`
 
-To use `mini.notify`, you can provide a custom `notify_func` in the `setup` call.
+To use `mini.notify`, you can provide a custom `notify_func` in the `setup` call. The following example shows the correct way to do this, including the necessary checks to ensure `mini.notify` is ready to be used.
 
 ```lua
 require('show_type').setup({
   notify_func = function(msg)
-    -- This safely checks if mini.notify is available
-    local success, mini_notify = pcall(require, 'mini.notify')
-    if success and mini_notify and mini_notify.make then
-      mini_notify.make(msg, 'info', { title = 'Type' })()
+    if _G.MiniNotify and _G.MiniNotify.make_notify then
+      local notify = _G.MiniNotify.make_notify()
+      notify(msg, vim.log.levels.INFO, { title = 'Type', timeout = 5000 })
     else
       vim.notify(msg, vim.log.levels.INFO, { title = 'Type' })
     end
@@ -68,7 +67,9 @@ require('show_type').setup({
 ```
 
 **Important Note for `lazy.nvim` users:**
-If you use `lazy.nvim` and want to use `mini.notify` with this plugin, you must explicitly declare the dependency to ensure `mini.nvim` is loaded first. Here is a complete example for your `lazy.nvim` configuration:
+If you use `lazy.nvim` and want to use `mini.notify` with this plugin, you must explicitly declare the dependency to ensure `mini.nvim` is loaded first. It is also recommended to set `lazy = false` for `mini.nvim` to ensure it is configured at startup.
+
+Here is a complete example for your `lazy.nvim` configuration:
 
 ```lua
 {
@@ -77,10 +78,9 @@ If you use `lazy.nvim` and want to use `mini.notify` with this plugin, you must 
   config = function()
     require('show_type').setup({
       notify_func = function(msg)
-        -- Your notify_func using mini.notify
-        local success, mini_notify = pcall(require, 'mini.notify')
-        if success and mini_notify and mini_notify.make then
-          mini_notify.make(msg, 'info', { title = 'Type' })()
+        if _G.MiniNotify and _G.MiniNotify.make_notify then
+          local notify = _G.MiniNotify.make_notify()
+          notify(msg, vim.log.levels.INFO, { title = 'Type', timeout = 5000 })
         else
           vim.notify(msg, vim.log.levels.INFO, { title = 'Type' })
         end

--- a/lua/show_type/init.lua
+++ b/lua/show_type/init.lua
@@ -55,7 +55,15 @@ end
 
 function M.show()
   local bufnr = vim.api.nvim_get_current_buf()
-  local params = vim.lsp.util.make_position_params()
+
+  -- Get position_encoding from the active LSP client to avoid a warning.
+  local clients = vim.lsp.get_clients({ bufnr = bufnr })
+  local encoding = 'utf-16' -- A safe default if no client is found.
+  if clients and #clients > 0 and clients[1].offset_encoding then
+    encoding = clients[1].offset_encoding
+  end
+
+  local params = vim.lsp.util.make_position_params(0, encoding)
 
   local handler = function(results_map)
     if not results_map or vim.tbl_isempty(results_map) then


### PR DESCRIPTION
This commit includes two main improvements:

1.  The `position_encoding` warning from `vim.lsp.util.make_position_params` has been suppressed by explicitly providing the encoding of the active LSP client. This makes the plugin cleaner to use.

2.  The `README.md` has been updated with the final, correct example for integrating with `mini.notify`. This includes a detailed explanation for `lazy.nvim` users on how to correctly configure the dependency to avoid loading order issues.

These changes finalize the plugin's functionality and documentation.